### PR TITLE
Don't load the weights during model training

### DIFF
--- a/train_model.ipynb
+++ b/train_model.ipynb
@@ -154,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.load_weights('weights/faster_rcnn.h5', by_name=True)"
+    "#model.load_weights('weights/faster_rcnn.h5', by_name=True)"
    ]
   },
   {


### PR DESCRIPTION
We are training from scratch in the code above this line. I left it as a comment in case someone wants to load a pretrained model. See https://github.com/Viredery/tf-eager-fasterrcnn/issues/27#issuecomment-2263461724.